### PR TITLE
fix QTextStream warnings during partitura loading

### DIFF
--- a/Include/ifile/CCompactXmlFileReadArchive.cpp
+++ b/Include/ifile/CCompactXmlFileReadArchive.cpp
@@ -48,6 +48,12 @@ bool CCompactXmlFileReadArchive::OpenFile(const QString& filePath)
 }
 
 
+bool CCompactXmlFileReadArchive::IsOpen() const
+{
+	return !m_openFileName.isEmpty();
+}
+
+
 // protected methods
 
 // reimplemented (istd::ILogger)

--- a/Include/ifile/CCompactXmlFileReadArchive.h
+++ b/Include/ifile/CCompactXmlFileReadArchive.h
@@ -37,6 +37,7 @@ public:
 				const iser::CArchiveTag& rootTag = s_acfRootTag);
 
 	bool OpenFile(const QString& filePath);
+	bool IsOpen() const override;
 
 protected:
 	// reimplemented (istd::ILogger)

--- a/Include/ifile/CCompactXmlFileWriteArchive.cpp
+++ b/Include/ifile/CCompactXmlFileWriteArchive.cpp
@@ -45,6 +45,12 @@ bool CCompactXmlFileWriteArchive::OpenFile(const QString& filePath)
 }
 
 
+bool CCompactXmlFileWriteArchive::IsOpen() const
+{
+	return m_file.isOpen();
+}
+
+
 bool CCompactXmlFileWriteArchive::Flush()
 {
 	BaseClass::Flush();

--- a/Include/ifile/CCompactXmlFileWriteArchive.h
+++ b/Include/ifile/CCompactXmlFileWriteArchive.h
@@ -40,6 +40,7 @@ public:
 	~CCompactXmlFileWriteArchive();
 
 	bool OpenFile(const QString& filePath);
+	bool IsOpen() const override;
 
 	bool Flush();
 

--- a/Include/ifile/CJsonFileReadArchive.cpp
+++ b/Include/ifile/CJsonFileReadArchive.cpp
@@ -36,4 +36,10 @@ bool CJsonFileReadArchive::OpenFile(const QString &filePath)
 }
 
 
+bool CJsonFileReadArchive::IsOpen() const
+{
+	return m_file.isOpen();
+}
+
+
 } // namespace ifile

--- a/Include/ifile/CJsonFileReadArchive.h
+++ b/Include/ifile/CJsonFileReadArchive.h
@@ -21,6 +21,7 @@ public:
 	CJsonFileReadArchive(const QString& filePath = "", bool serializeHeader = true);
 
 	bool OpenFile(const QString& filePath);
+	bool IsOpen() const override;
 
 private:
 	QFile m_file;

--- a/Include/ifile/CJsonFileWriteArchive.cpp
+++ b/Include/ifile/CJsonFileWriteArchive.cpp
@@ -48,4 +48,10 @@ bool CJsonFileWriteArchive::OpenFile(const QString &filePath)
 }
 
 
+bool CJsonFileWriteArchive::IsOpen() const
+{
+	return m_file.isOpen();
+}
+
+
 } // namespace ifile

--- a/Include/ifile/CJsonFileWriteArchive.h
+++ b/Include/ifile/CJsonFileWriteArchive.h
@@ -30,6 +30,7 @@ public:
 	~CJsonFileWriteArchive();
 
 	bool OpenFile(const QString& filePath);
+	bool IsOpen() const override;
 
 private:
 	QFile m_file;

--- a/Include/ifile/CSimpleXmlFileReadArchive.cpp
+++ b/Include/ifile/CSimpleXmlFileReadArchive.cpp
@@ -23,6 +23,12 @@ CSimpleXmlFileReadArchive::CSimpleXmlFileReadArchive(const QString& filePath, bo
 }
 
 
+bool CSimpleXmlFileReadArchive::IsOpen() const
+{
+	return m_file.isOpen();
+}
+
+
 CSimpleXmlFileReadArchive::~CSimpleXmlFileReadArchive()
 {
 	if (m_file.isOpen()){

--- a/Include/ifile/CSimpleXmlFileReadArchive.h
+++ b/Include/ifile/CSimpleXmlFileReadArchive.h
@@ -34,6 +34,8 @@ public:
 	explicit CSimpleXmlFileReadArchive(const QString& filePath, bool serializeHeader = true, const iser::CArchiveTag& rootTag = s_acfRootTag);
 	virtual ~CSimpleXmlFileReadArchive();
 
+	bool IsOpen() const override;
+
 protected:
 	// reimplemented (istd::ILogger)
 	virtual void DecorateMessage(

--- a/Include/ifile/CSimpleXmlFileWriteArchive.cpp
+++ b/Include/ifile/CSimpleXmlFileWriteArchive.cpp
@@ -42,6 +42,12 @@ CSimpleXmlFileWriteArchive::~CSimpleXmlFileWriteArchive()
 }
 
 
+bool CSimpleXmlFileWriteArchive::IsOpen() const
+{
+	return m_file.isOpen();
+}
+
+
 // protected methods
 
 // reimplemented (iser::CXmlWriteArchiveBase)

--- a/Include/ifile/CSimpleXmlFileWriteArchive.h
+++ b/Include/ifile/CSimpleXmlFileWriteArchive.h
@@ -37,6 +37,8 @@ public:
 				const iser::CArchiveTag& rootTag = s_acfRootTag);
 	virtual ~CSimpleXmlFileWriteArchive();
 
+	bool IsOpen() const override;
+
 protected:
 	// reimplemented (iser::CXmlWriteArchiveBase)
 	virtual bool WriteString(const QByteArray& value) override;

--- a/Include/ipackage/CPackagesLoaderComp.cpp
+++ b/Include/ipackage/CPackagesLoaderComp.cpp
@@ -346,12 +346,14 @@ bool CPackagesLoaderComp::RegisterPackageFile(const QString& file)
 
 			QString metaInfoFile(packageDir.absoluteFilePath("General.xml"));
 			ifile::CSimpleXmlFileReadArchive archive(metaInfoFile);
-			if (!infoPtr->SerializeMeta(archive)){
-				SendWarningMessage(
-							ifile::IFilePersistence::MI_CANNOT_LOAD,
-							QObject::tr("Cannot load meta description for registry %1 (%2)")
-										.arg(QString(packageId))
-										.arg(metaInfoFile));
+			if (archive.IsOpen()){
+				if (!infoPtr->SerializeMeta(archive)){
+					SendWarningMessage(
+								ifile::IFilePersistence::MI_CANNOT_LOAD,
+								QObject::tr("Cannot load meta description for registry %1 (%2)")
+											.arg(QString(packageId))
+											.arg(metaInfoFile));
+				}
 			}
 
 			RegisterEmbeddedComponentInfo(packageId, infoPtr);

--- a/Include/iser/CReadArchiveBase.cpp
+++ b/Include/iser/CReadArchiveBase.cpp
@@ -14,6 +14,12 @@ bool CReadArchiveBase::IsStoring() const
 }
 
 
+bool CReadArchiveBase::IsOpen() const
+{
+	return true;
+}
+
+
 const IVersionInfo& CReadArchiveBase::GetVersionInfo() const
 {
 	return m_versionInfo;

--- a/Include/iser/CReadArchiveBase.h
+++ b/Include/iser/CReadArchiveBase.h
@@ -19,6 +19,7 @@ class CReadArchiveBase: public CArchiveBase
 public:
 	// reimplemented (iser::IArchive)
 	virtual bool IsStoring() const override;
+	virtual bool IsOpen() const override;
 	virtual const IVersionInfo& GetVersionInfo() const override;
 	virtual bool ProcessBits(void* dataPtr, int bitsCount, int bytesCount) override;
 

--- a/Include/iser/CWriteArchiveBase.cpp
+++ b/Include/iser/CWriteArchiveBase.cpp
@@ -18,6 +18,12 @@ bool CWriteArchiveBase::IsStoring() const
 }
 
 
+bool CWriteArchiveBase::IsOpen() const
+{
+	return true;
+}
+
+
 const IVersionInfo& CWriteArchiveBase::GetVersionInfo() const
 {
 	if (m_versionInfoPtr != NULL){

--- a/Include/iser/CWriteArchiveBase.h
+++ b/Include/iser/CWriteArchiveBase.h
@@ -21,6 +21,7 @@ class CWriteArchiveBase: public CArchiveBase
 public:
 	// reimplemented (iser::IArchive)
 	virtual bool IsStoring() const override;
+	virtual bool IsOpen() const override;
 	virtual const IVersionInfo& GetVersionInfo() const override;
 	virtual bool ProcessBits(void* dataPtr, int bitsCount, int bytesCount) override;
 

--- a/Include/iser/IArchive.h
+++ b/Include/iser/IArchive.h
@@ -205,6 +205,20 @@ public:
 	virtual bool IsStoring() const = 0;
 
 	/**
+		Checks if the archive was successfully opened and is ready for use.
+
+		For file-based archives this reflects whether the underlying file was opened
+		successfully. For in-memory archives (string buffers, etc.) this always
+		returns true because there is no external resource that can fail to open.
+
+		Always check IsOpen() before calling Serialize() on a file-based archive to
+		avoid serializing into an archive that has no backing device.
+
+		\return true if the archive is ready for use, false if it failed to open
+	*/
+	virtual bool IsOpen() const = 0;
+
+	/**
 		Checks if skipping to the end of a tag on EndTag() is supported.
 		
 		Some archive types (like XML) support skipping unread content within a tag,


### PR DESCRIPTION
Фиксит вот этот спам 

```
[244/285] Start convert LunaAppQml.rc
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
Variable: "IACFDIR_BUILD" used in: "$(IACFDIR_BUILD)/Bin/$(ConfigurationName)" could not be resolved
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
I43024: Processing file C:/work/trunk/GmgProducts/Luna/Source/LunaApp/VC/LunaAppQml.rc.xtracf to C:/work/build-x64-debug/Temp/garden/Generated/Acf/LunaAppQml.rc
[245/285] Start convert LunaApp.rc
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
Variable: "IACFDIR_BUILD" used in: "$(IACFDIR_BUILD)/Bin/$(ConfigurationName)" could not be resolved
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
QTextStream: No device
```